### PR TITLE
strings: add wrapper types to use instead of functions

### DIFF
--- a/Library/Core/LocalizedString.swift
+++ b/Library/Core/LocalizedString.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// Wrappers around StringResourceType to handle Localized String with Format
+
+public struct LocalizedStringNoArg {
+  let resource: StringResourceType
+
+  public func translated() -> String {
+    return resource.translated()
+  }
+}
+
+public struct LocalizedStringOneArg<T: CVarArg> {
+  let resource: Rswift.StringResourceType
+
+  public func translated(_ arg: T) -> String {
+    return String.localizedStringWithFormat(resource.translated(), arg)
+  }
+}
+
+public struct LocalizedStringTwoArgs<T: CVarArg, U: CVarArg> {
+  let resource: Rswift.StringResourceType
+
+  public func translated(_ arg1: T, _ arg2: U) -> String {
+    return String.localizedStringWithFormat(resource.translated(), arg1, arg2)
+  }
+}
+
+public struct LocalizedStringThreeArgs<T: CVarArg, U: CVarArg, V: CVarArg> {
+  let resource: Rswift.StringResourceType
+
+  public func translated(_ arg1: T, _ arg2: U, _ arg3: V) -> String {
+    return String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3)
+  }
+}
+
+public struct LocalizedStringFourArgs<T: CVarArg, U: CVarArg, V: CVarArg, W: CVarArg> {
+  let resource: Rswift.StringResourceType
+
+  public func translated(_ arg1: T, _ arg2: U, _ arg3: V, _ arg4: W) -> String {
+    return String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3, arg4)
+  }
+}
+
+public struct LocalizedStringFiveArgs<T: CVarArg, U: CVarArg, V: CVarArg, W: CVarArg, X: CVarArg> {
+  let resource: Rswift.StringResourceType
+
+  public func translated(_ arg1: T, _ arg2: U, _ arg3: V, _ arg4: W, _ arg5: X) -> String {
+    return String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3, arg4, arg5)
+  }
+}

--- a/Library/Core/StringResource.swift
+++ b/Library/Core/StringResource.swift
@@ -25,6 +25,9 @@ public protocol StringResourceType {
   
   /// Comment directly before and/or after the string, if any
   var comment: String? { get }
+
+  /// Returns the translated string
+  func translated() -> String
 }
 
 public struct StringResource: StringResourceType {
@@ -50,5 +53,10 @@ public struct StringResource: StringResourceType {
     self.bundle = bundle
     self.locales = locales
     self.comment = comment
+  }
+
+  /// Returns the translated string
+  public func translated() -> String {
+    return NSLocalizedString(key, tableName: tableName, bundle: bundle, comment: comment ?? "")
   }
 }

--- a/R.swift.Library.xcodeproj/project.pbxproj
+++ b/R.swift.Library.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		806E69BA1C42BDE000DE3A8B /* UIViewController+NibResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9C71C14995800D16A0C /* UIViewController+NibResource.swift */; };
 		806E69BB1C42BDE000DE3A8B /* UIViewController+StoryboardSegueIdentifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543F9C91C14998800D16A0C /* UIViewController+StoryboardSegueIdentifierProtocol.swift */; };
 		806E69BC1C42BDE300DE3A8B /* RswiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D592465D1C117A55007F94C7 /* RswiftTests.swift */; };
+		A71DE402232A9DEA00E9D495 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71DE401232A9DEA00E9D495 /* LocalizedString.swift */; };
+		A71DE403232A9DEA00E9D495 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71DE401232A9DEA00E9D495 /* LocalizedString.swift */; };
+		A71DE404232A9DEA00E9D495 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71DE401232A9DEA00E9D495 /* LocalizedString.swift */; };
 		D51335271C959DF20014C9D4 /* StoryboardViewControllerResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51335261C959DF20014C9D4 /* StoryboardViewControllerResource.swift */; };
 		D51335291C95A79B0014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51335281C95A79B0014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift */; };
 		D513352A1C95B7510014C9D4 /* StoryboardViewControllerResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51335261C959DF20014C9D4 /* StoryboardViewControllerResource.swift */; };
@@ -107,6 +110,7 @@
 		2F5FBC4021355A1400A83A69 /* Rswift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rswift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		806E69921C42BD9C00DE3A8B /* Rswift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rswift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		806E699B1C42BD9C00DE3A8B /* RswiftTests-tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RswiftTests-tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A71DE401232A9DEA00E9D495 /* LocalizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedString.swift; sourceTree = "<group>"; };
 		D51335261C959DF20014C9D4 /* StoryboardViewControllerResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardViewControllerResource.swift; sourceTree = "<group>"; };
 		D51335281C95A79B0014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+StoryboardViewControllerResource.swift"; sourceTree = "<group>"; };
 		D53F19231C229D7200AE2FAD /* Validatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Validatable.swift; sourceTree = "<group>"; };
@@ -218,6 +222,7 @@
 				D51335261C959DF20014C9D4 /* StoryboardViewControllerResource.swift */,
 				E250BE961CCBF60300CC71DE /* StringResource.swift */,
 				D53F19231C229D7200AE2FAD /* Validatable.swift */,
+				A71DE401232A9DEA00E9D495 /* LocalizedString.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -501,6 +506,7 @@
 				2F5FBC4821355AC400A83A69 /* ColorResource.swift in Sources */,
 				2F5FBC4C21355ADF00A83A69 /* FileResource.swift in Sources */,
 				2F5FBC5221355ADF00A83A69 /* StoryboardResource.swift in Sources */,
+				A71DE404232A9DEA00E9D495 /* LocalizedString.swift in Sources */,
 				2F5FBC5521355ADF00A83A69 /* StringResource.swift in Sources */,
 				2F5FBC4B21355ADB00A83A69 /* Data+FileResource.swift in Sources */,
 				2F5FBC5021355ADF00A83A69 /* NibResource.swift in Sources */,
@@ -527,6 +533,7 @@
 				806E69B41C42BDE000DE3A8B /* UICollectionView+ReuseIdentifierProtocol.swift in Sources */,
 				806E69B11C42BDE000DE3A8B /* NibResource+UIKit.swift in Sources */,
 				806E69B71C42BDE000DE3A8B /* UIStoryboard+StoryboardResource.swift in Sources */,
+				A71DE403232A9DEA00E9D495 /* LocalizedString.swift in Sources */,
 				806E69AC1C42BDDA00DE3A8B /* NibResource.swift in Sources */,
 				806E69BA1C42BDE000DE3A8B /* UIViewController+NibResource.swift in Sources */,
 				806E69B51C42BDE000DE3A8B /* UIFont+FontResource.swift in Sources */,
@@ -569,6 +576,7 @@
 				D57E1EB91C3E4C1A00DDA68F /* StoryboardResourceWithInitialController+UIKit.swift in Sources */,
 				D543F9BD1C14980600D16A0C /* ReuseIdentifierProtocol.swift in Sources */,
 				D543F9C11C14984300D16A0C /* NibResource.swift in Sources */,
+				A71DE402232A9DEA00E9D495 /* LocalizedString.swift in Sources */,
 				E2CA68EF1EE75992009C4DB4 /* UIColor+ColorResource.swift in Sources */,
 				D553F5851C44157000885232 /* ImageResource.swift in Sources */,
 				E20F34A71C92B44100338F81 /* Data+FileResource.swift in Sources */,


### PR DESCRIPTION
Adds wrappers that are meant to be used instead of functions in generated code. Limited to 3 args right now.