### PR TITLE
Add LocalizedString mutator

### DIFF
--- a/Library/Core/LocalizedString.swift
+++ b/Library/Core/LocalizedString.swift
@@ -9,6 +9,7 @@ public struct LocalizedStringNoArg {
     self.resource = resource
   }
 
+  // TODO: @scalbatty replace with `callAsFunction` when building on Swift 5.2
   public func translated() -> String {
     let localized = resource.translated()
     return LocalizedStringTransform.current.apply(localized)
@@ -22,6 +23,7 @@ public struct LocalizedStringOneArg<T: CVarArg> {
     self.resource = resource
   }
 
+  // TODO: @scalbatty replace with `callAsFunction` when building on Swift 5.2
   public func translated(_ arg: T) -> String {
     let localized = String.localizedStringWithFormat(resource.translated(), arg)
     return LocalizedStringTransform.current.apply(localized)
@@ -35,6 +37,7 @@ public struct LocalizedStringTwoArgs<T: CVarArg, U: CVarArg> {
     self.resource = resource
   }
 
+  // TODO: @scalbatty replace with `callAsFunction` when building on Swift 5.2
   public func translated(_ arg1: T, _ arg2: U) -> String {
     let localized = String.localizedStringWithFormat(resource.translated(), arg1, arg2)
     return LocalizedStringTransform.current.apply(localized)
@@ -48,6 +51,7 @@ public struct LocalizedStringThreeArgs<T: CVarArg, U: CVarArg, V: CVarArg> {
     self.resource = resource
   }
 
+  // TODO: @scalbatty replace with `callAsFunction` when building on Swift 5.2
   public func translated(_ arg1: T, _ arg2: U, _ arg3: V) -> String {
     let localized = String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3)
     return LocalizedStringTransform.current.apply(localized)
@@ -61,6 +65,7 @@ public struct LocalizedStringFourArgs<T: CVarArg, U: CVarArg, V: CVarArg, W: CVa
     self.resource = resource
   }
 
+  // TODO: @scalbatty replace with `callAsFunction` when building on Swift 5.2
   public func translated(_ arg1: T, _ arg2: U, _ arg3: V, _ arg4: W) -> String {
     let localized = String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3, arg4)
     return LocalizedStringTransform.current.apply(localized)
@@ -74,6 +79,7 @@ public struct LocalizedStringFiveArgs<T: CVarArg, U: CVarArg, V: CVarArg, W: CVa
     self.resource = resource
   }
 
+  // TODO: @scalbatty replace with `callAsFunction` when building on Swift 5.2
   public func translated(_ arg1: T, _ arg2: U, _ arg3: V, _ arg4: W, _ arg5: X) -> String {
     let localized = String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3, arg4, arg5)
     return LocalizedStringTransform.current.apply(localized)

--- a/Library/Core/LocalizedString.swift
+++ b/Library/Core/LocalizedString.swift
@@ -10,7 +10,8 @@ public struct LocalizedStringNoArg {
   }
 
   public func translated() -> String {
-    return resource.translated()
+    let localized = resource.translated()
+    return LocalizedStringTransform.current.apply(localized)
   }
 }
 
@@ -22,7 +23,8 @@ public struct LocalizedStringOneArg<T: CVarArg> {
   }
 
   public func translated(_ arg: T) -> String {
-    return String.localizedStringWithFormat(resource.translated(), arg)
+    let localized = String.localizedStringWithFormat(resource.translated(), arg)
+    return LocalizedStringTransform.current.apply(localized)
   }
 }
 
@@ -34,7 +36,8 @@ public struct LocalizedStringTwoArgs<T: CVarArg, U: CVarArg> {
   }
 
   public func translated(_ arg1: T, _ arg2: U) -> String {
-    return String.localizedStringWithFormat(resource.translated(), arg1, arg2)
+    let localized = String.localizedStringWithFormat(resource.translated(), arg1, arg2)
+    return LocalizedStringTransform.current.apply(localized)
   }
 }
 
@@ -46,7 +49,8 @@ public struct LocalizedStringThreeArgs<T: CVarArg, U: CVarArg, V: CVarArg> {
   }
 
   public func translated(_ arg1: T, _ arg2: U, _ arg3: V) -> String {
-    return String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3)
+    let localized = String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3)
+    return LocalizedStringTransform.current.apply(localized)
   }
 }
 
@@ -58,7 +62,8 @@ public struct LocalizedStringFourArgs<T: CVarArg, U: CVarArg, V: CVarArg, W: CVa
   }
 
   public func translated(_ arg1: T, _ arg2: U, _ arg3: V, _ arg4: W) -> String {
-    return String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3, arg4)
+    let localized = String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3, arg4)
+    return LocalizedStringTransform.current.apply(localized)
   }
 }
 
@@ -70,6 +75,7 @@ public struct LocalizedStringFiveArgs<T: CVarArg, U: CVarArg, V: CVarArg, W: CVa
   }
 
   public func translated(_ arg1: T, _ arg2: U, _ arg3: V, _ arg4: W, _ arg5: X) -> String {
-    return String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3, arg4, arg5)
+    let localized = String.localizedStringWithFormat(resource.translated(), arg1, arg2, arg3, arg4, arg5)
+    return LocalizedStringTransform.current.apply(localized)
   }
 }

--- a/Library/Core/LocalizedStringTransform.swift
+++ b/Library/Core/LocalizedStringTransform.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Registered singleton-based function type that transforms
+/// every localizedString produced by the library.
+///
+/// Usage:
+/// - Register a transform: `LocalizedStringTransform.register { $0.localizedUppercase }`
+/// to have all localized strings uppercased.
+/// - Return to non-mutating mode: `LocalizedStringTransform.register(.identity)`
+///
+/// Remarks:
+/// - only one transform can be registered at a time
+/// - registration should happen at app init time, thread safety is not guaranteed
+///
+public struct LocalizedStringTransform {
+  static var current: LocalizedStringTransform = .identity
+
+  private let transform: (String) -> String
+
+  private init(transform: @escaping (String) -> String) {
+    self.transform = transform
+  }
+
+  func apply(_ input: String) -> String {
+    return transform(input)
+  }
+}
+
+public extension LocalizedStringTransform {
+  static let `identity` = LocalizedStringTransform { $0 }
+
+  static func register(_ transform: @escaping (String) -> String) {
+    current = LocalizedStringTransform(transform: transform)
+  }
+
+  static func register(_ transform: LocalizedStringTransform) {
+    current = transform
+  }
+}

--- a/Library/Core/LocalizedStringTransform.swift
+++ b/Library/Core/LocalizedStringTransform.swift
@@ -21,6 +21,7 @@ public struct LocalizedStringTransform {
     self.transform = transform
   }
 
+  // TODO: @scalbatty replace with `callAsFunction` when building on Swift 5.2
   func apply(_ input: String) -> String {
     return transform(input)
   }

--- a/R.swift.Library.xcodeproj/project.pbxproj
+++ b/R.swift.Library.xcodeproj/project.pbxproj
@@ -47,6 +47,9 @@
 		A71DE402232A9DEA00E9D495 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71DE401232A9DEA00E9D495 /* LocalizedString.swift */; };
 		A71DE403232A9DEA00E9D495 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71DE401232A9DEA00E9D495 /* LocalizedString.swift */; };
 		A71DE404232A9DEA00E9D495 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71DE401232A9DEA00E9D495 /* LocalizedString.swift */; };
+		A77AA1BF24348EE20098BC0F /* LocalizedStringTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA1BE24348EE20098BC0F /* LocalizedStringTransform.swift */; };
+		A77AA1C024348EE20098BC0F /* LocalizedStringTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA1BE24348EE20098BC0F /* LocalizedStringTransform.swift */; };
+		A77AA1C124348EE20098BC0F /* LocalizedStringTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA1BE24348EE20098BC0F /* LocalizedStringTransform.swift */; };
 		D51335271C959DF20014C9D4 /* StoryboardViewControllerResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51335261C959DF20014C9D4 /* StoryboardViewControllerResource.swift */; };
 		D51335291C95A79B0014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51335281C95A79B0014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift */; };
 		D513352A1C95B7510014C9D4 /* StoryboardViewControllerResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51335261C959DF20014C9D4 /* StoryboardViewControllerResource.swift */; };
@@ -111,6 +114,7 @@
 		806E69921C42BD9C00DE3A8B /* Rswift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rswift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		806E699B1C42BD9C00DE3A8B /* RswiftTests-tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RswiftTests-tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A71DE401232A9DEA00E9D495 /* LocalizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedString.swift; sourceTree = "<group>"; };
+		A77AA1BE24348EE20098BC0F /* LocalizedStringTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedStringTransform.swift; sourceTree = "<group>"; };
 		D51335261C959DF20014C9D4 /* StoryboardViewControllerResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardViewControllerResource.swift; sourceTree = "<group>"; };
 		D51335281C95A79B0014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+StoryboardViewControllerResource.swift"; sourceTree = "<group>"; };
 		D53F19231C229D7200AE2FAD /* Validatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Validatable.swift; sourceTree = "<group>"; };
@@ -223,6 +227,7 @@
 				E250BE961CCBF60300CC71DE /* StringResource.swift */,
 				D53F19231C229D7200AE2FAD /* Validatable.swift */,
 				A71DE401232A9DEA00E9D495 /* LocalizedString.swift */,
+				A77AA1BE24348EE20098BC0F /* LocalizedStringTransform.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -515,6 +520,7 @@
 				2F5FBC4A21355ADB00A83A69 /* Bundle+FileResource.swift in Sources */,
 				2F5FBC5821355B0200A83A69 /* UIColor+ColorResource.swift in Sources */,
 				2F5FBC5121355ADF00A83A69 /* ReuseIdentifierProtocol.swift in Sources */,
+				A77AA1C124348EE20098BC0F /* LocalizedStringTransform.swift in Sources */,
 				2F5FBC5621355ADF00A83A69 /* Validatable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -523,6 +529,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A77AA1C024348EE20098BC0F /* LocalizedStringTransform.swift in Sources */,
 				D5728B311C4D541200E38168 /* ImageResource.swift in Sources */,
 				D513352B1C95B7620014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift in Sources */,
 				D513352C1C95C61E0014C9D4 /* Data+FileResource.swift in Sources */,
@@ -566,6 +573,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A77AA1BF24348EE20098BC0F /* LocalizedStringTransform.swift in Sources */,
 				D543F9CA1C14998800D16A0C /* UIViewController+StoryboardSegueIdentifierProtocol.swift in Sources */,
 				D51335291C95A79B0014C9D4 /* UIStoryboard+StoryboardViewControllerResource.swift in Sources */,
 				D5E435AD1C3D00770091090C /* FileResource.swift in Sources */,


### PR DESCRIPTION
## Goal

Allow Pseudolocalization in client app: transform every LocalizedString so that it systematically includes non-latin characters + is ~40% longer + is wrapped in brackets.

Example: `Hello Playground` -> `[Ḥеęłḽöṓ, рḽâãуẏğṛṓоцṵиḍ]`

More details on [this article from Netflix](https://netflixtechblog.com/pseudo-localization-netflix-12fff76fbcbe)

## Constraints

- activate/deactivate Pseudolocalization at runtime using a flag (i.e. Tweak)
- ensure the Pseudolocalization code cannot be in the production binary (i.e. Scaffolding)
- apply the Pseudolocalization algorithm after the string has been formatted with arguments
- limit the code footprint on the R.swift library
- facilitate changes in the Pseudolocalization algorithm without having to rebuild dependency
- avoid having to rewrite all R.swift LocalizedString call sites following this change

## Solution

The R.swift library will just include a new `LocalizedStringMutator.current` singleton, by default using a non-changing (i.e. _identity_) mutator. Every `LocalizedString` type will pass its return value through this mutator before returning it.

The library client can register another `(String) -> (String)` mutator that will be applied to all `LocalizedString.translate()` calls.

Another PR will follow in `iosapp` to add the actual Pseudolocalization algorithm and integration.